### PR TITLE
feat: add GET /api/users/{id} endpoint

### DIFF
--- a/src/main/java/com/doron/shaul/usermanagement/controller/UserController.java
+++ b/src/main/java/com/doron/shaul/usermanagement/controller/UserController.java
@@ -19,4 +19,11 @@ public class UserController {
         User createdUser = userService.createUser(user);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
     }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUser(@PathVariable Long id) {
+        return userService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
 }

--- a/src/main/java/com/doron/shaul/usermanagement/service/UserService.java
+++ b/src/main/java/com/doron/shaul/usermanagement/service/UserService.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -17,5 +19,9 @@ public class UserService {
             throw new IllegalArgumentException("Email already exists");
         }
         return userRepository.save(user);
+    }
+
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
     }
 }

--- a/src/test/java/com/doron/shaul/usermanagement/controller/UserControllerTest.java
+++ b/src/test/java/com/doron/shaul/usermanagement/controller/UserControllerTest.java
@@ -10,9 +10,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Optional;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(UserController.class)
@@ -63,5 +65,29 @@ class UserControllerTest {
                         .content(objectMapper.writeValueAsString(user)))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string("Email already exists"));
+    }
+
+    @Test
+    void getUser_UserExists_ReturnsOk() throws Exception {
+        User user = new User();
+        user.setId(1L);
+        user.setName("Jane Doe");
+        user.setEmail("jane@example.com");
+
+        when(userService.findById(1L)).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/api/users/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Jane Doe"))
+                .andExpect(jsonPath("$.email").value("jane@example.com"));
+    }
+
+    @Test
+    void getUser_UserNotFound_ReturnsNotFound() throws Exception {
+        when(userService.findById(99L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/users/99"))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/doron/shaul/usermanagement/service/UserServiceTest.java
+++ b/src/test/java/com/doron/shaul/usermanagement/service/UserServiceTest.java
@@ -9,6 +9,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -57,5 +59,27 @@ class UserServiceTest {
         assertEquals("Email already exists", exception.getMessage());
         verify(userRepository, times(1)).existsByEmail(testUser.getEmail());
         verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void findById_UserExists_ReturnsUser() {
+        testUser.setId(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+        Optional<User> result = userService.findById(1L);
+
+        assertTrue(result.isPresent());
+        assertEquals("John Doe", result.get().getName());
+        verify(userRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void findById_UserNotFound_ReturnsEmpty() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        Optional<User> result = userService.findById(99L);
+
+        assertTrue(result.isEmpty());
+        verify(userRepository, times(1)).findById(99L);
     }
 }


### PR DESCRIPTION
## Summary
- Adds GET endpoint to fetch a user by ID
- Returns 200 with user data, or 404 if not found

## Changes
- `UserService`: added `findById` method delegating to repository
- `UserController`: added `GET /{id}` endpoint
- `UserServiceTest`: added tests for found and not-found cases
- `UserControllerTest`: added tests for 200 and 404 responses

## Testing
- All 8 tests pass (`mvn test`)

Closes #1