### PR TITLE
feat: add update and delete user APIs

### DIFF
--- a/src/main/java/com/doron/shaul/usermanagement/controller/UserController.java
+++ b/src/main/java/com/doron/shaul/usermanagement/controller/UserController.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -25,5 +27,21 @@ public class UserController {
         return userService.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<User> updateUser(@PathVariable Long id, @RequestBody Map<String, String> body) {
+        String name = body.get("name");
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Name is required");
+        }
+        User updatedUser = userService.updateUserName(id, name);
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/doron/shaul/usermanagement/service/UserService.java
+++ b/src/main/java/com/doron/shaul/usermanagement/service/UserService.java
@@ -24,4 +24,20 @@ public class UserService {
     public Optional<User> findById(Long id) {
         return userRepository.findById(id);
     }
+
+    @Transactional
+    public User updateUserName(Long id, String name) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + id));
+        user.setName(name);
+        return userRepository.save(user);
+    }
+
+    @Transactional
+    public void deleteUser(Long id) {
+        if (!userRepository.existsById(id)) {
+            throw new IllegalArgumentException("User not found with id: " + id);
+        }
+        userRepository.deleteById(id);
+    }
 }

--- a/src/test/java/com/doron/shaul/usermanagement/service/UserServiceTest.java
+++ b/src/test/java/com/doron/shaul/usermanagement/service/UserServiceTest.java
@@ -82,4 +82,61 @@ class UserServiceTest {
         assertTrue(result.isEmpty());
         verify(userRepository, times(1)).findById(99L);
     }
+
+    @Test
+    void updateUserName_UserExists_ReturnsUpdatedUser() {
+        testUser.setId(1L);
+        User updatedUser = new User();
+        updatedUser.setId(1L);
+        updatedUser.setName("Updated Name");
+        updatedUser.setEmail("john@example.com");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(userRepository.save(testUser)).thenReturn(updatedUser);
+
+        User result = userService.updateUserName(1L, "Updated Name");
+
+        assertNotNull(result);
+        assertEquals("Updated Name", result.getName());
+        verify(userRepository, times(1)).findById(1L);
+        verify(userRepository, times(1)).save(testUser);
+    }
+
+    @Test
+    void updateUserName_UserNotFound_ThrowsException() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> userService.updateUserName(99L, "New Name")
+        );
+
+        assertEquals("User not found with id: 99", exception.getMessage());
+        verify(userRepository, times(1)).findById(99L);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void deleteUser_UserExists_DeletesSuccessfully() {
+        when(userRepository.existsById(1L)).thenReturn(true);
+
+        userService.deleteUser(1L);
+
+        verify(userRepository, times(1)).existsById(1L);
+        verify(userRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void deleteUser_UserNotFound_ThrowsException() {
+        when(userRepository.existsById(99L)).thenReturn(false);
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> userService.deleteUser(99L)
+        );
+
+        assertEquals("User not found with id: 99", exception.getMessage());
+        verify(userRepository, times(1)).existsById(99L);
+        verify(userRepository, never()).deleteById(any(Long.class));
+    }
 }


### PR DESCRIPTION
## Summary
- Implements `PUT /api/users/{id}` to update a user's name
- Implements `DELETE /api/users/{id}` to remove a user

## Changes
- **UserService**: Added `updateUserName(id, name)` and `deleteUser(id)` methods; both throw `IllegalArgumentException` (400) when the user does not exist
- **UserController**: Added `PUT /{id}` endpoint accepting `{"name": "..."}` body, and `DELETE /{id}` endpoint returning 204 No Content
- **UserServiceTest**: 4 new tests covering success and not-found paths for both methods
- **UserControllerTest**: 5 new tests covering success, blank-name validation, not-found, and delete scenarios

## Testing
- All 17 tests pass (8 service, 9 controller)
- Both success and error paths covered for every new endpoint

Closes #3