### PR TITLE
feat: add update and delete user endpoints

### DIFF
--- a/src/main/java/com/doron/shaul/usermanagement/controller/UserController.java
+++ b/src/main/java/com/doron/shaul/usermanagement/controller/UserController.java
@@ -26,4 +26,16 @@ public class UserController {
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<User> updateUser(@PathVariable Long id, @Valid @RequestBody User user) {
+        User updatedUser = userService.updateUser(id, user);
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/doron/shaul/usermanagement/service/UserService.java
+++ b/src/main/java/com/doron/shaul/usermanagement/service/UserService.java
@@ -3,8 +3,10 @@ package com.doron.shaul.usermanagement.service;
 import com.doron.shaul.usermanagement.model.User;
 import com.doron.shaul.usermanagement.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
@@ -23,5 +25,21 @@ public class UserService {
 
     public Optional<User> findById(Long id) {
         return userRepository.findById(id);
+    }
+
+    @Transactional
+    public User updateUser(Long id, User user) {
+        User existing = userRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        existing.setName(user.getName());
+        return userRepository.save(existing);
+    }
+
+    @Transactional
+    public void deleteUser(Long id) {
+        if (!userRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+        }
+        userRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
## Summary
- Added `PUT /api/users/{id}` to update a user's name (email and createdAt are immutable after creation)
- Added `DELETE /api/users/{id}` to remove a user
- Both endpoints return 404 when the user does not exist

## Changes
- `UserController.java` — two new endpoints (`@PutMapping`, `@DeleteMapping`)
- `UserService.java` — `updateUser()` fetches the existing record and applies only the name; `deleteUser()` guards with `existsById` before deletion; both use `ResponseStatusException(NOT_FOUND)` for missing users
- `UserServiceTest.java` — 4 new tests covering success and not-found paths for both methods
- `UserControllerTest.java` — 4 new tests covering 200/204 success and 404 error responses

## Testing
- [x] `updateUser` — name updated, email unchanged (verified via distinct request email)
- [x] `updateUser` — 404 when user missing
- [x] `deleteUser` — 204 on success, `deleteById` invoked
- [x] `deleteUser` — 404 when user missing
- [x] All 16 tests pass (`mvn test`)

Closes #3